### PR TITLE
Add profile page

### DIFF
--- a/frontend/src/components/navBar.vue
+++ b/frontend/src/components/navBar.vue
@@ -66,8 +66,7 @@ const logout = () => {
 }
 
 const goToProfile = () => {
-  console.log(`profile`)
-  // router.push('/profile')
+  router.push('/profile')
 }
 </script>
 <style scoped>

--- a/frontend/src/components/views/profile.vue
+++ b/frontend/src/components/views/profile.vue
@@ -1,0 +1,76 @@
+<template>
+  <v-container class="py-12">
+    <v-row justify="center">
+      <v-col cols="12" sm="8" md="6" lg="4">
+        <v-card elevation="8" class="pa-6 profile-card">
+          <h2 class="text-center mb-4">Профиль</h2>
+          <v-form>
+            <v-text-field
+              v-model="localUser.user_name"
+              label="Имя"
+              prepend-inner-icon="mdi-account"
+              outlined
+              dense
+              readonly
+              class="mt-2"
+            />
+            <v-text-field
+              v-model="localUser.user_surname"
+              label="Фамилия"
+              prepend-inner-icon="mdi-account"
+              outlined
+              dense
+              readonly
+              class="mt-2"
+            />
+            <v-text-field
+              v-model="localUser.user_nickname"
+              label="Никнейм"
+              prepend-inner-icon="mdi-face-man-profile"
+              outlined
+              dense
+              readonly
+              class="mt-2"
+            />
+            <v-text-field
+              v-model="localUser.user_login"
+              label="Email"
+              type="email"
+              prepend-inner-icon="mdi-email"
+              outlined
+              dense
+              readonly
+              class="mt-2"
+            />
+          </v-form>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useUser } from '@/components/store/userStore';
+
+const { user } = useUser();
+
+const localUser = ref({
+  user_name: '',
+  user_surname: '',
+  user_nickname: '',
+  user_login: ''
+});
+
+if (user.value) {
+  localUser.value = { ...user.value };
+}
+</script>
+
+<style scoped>
+.profile-card {
+  background-color: var(--color-background);
+  color: var(--color-text);
+  border-radius: 12px;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -4,6 +4,7 @@ import MainComponent from '@/components/index.vue';
 import catalog from '@/components/views/catalog.vue';
 import authorization from '@/components/views/authorization.vue';
 import registration from '@/components/views/registration.vue';
+import profile from '@/components/views/profile.vue';
 import itemMain from '@/components/views/itemView/itemMain.vue';
 
 // 404
@@ -14,6 +15,7 @@ const routes = [
   { path: '/catalog', component: catalog },
   { path: '/login', component: authorization },
   { path: '/registration', component: registration },
+  { path: '/profile', component: profile },
 
   { path: '/item/:id', component: itemMain },
 


### PR DESCRIPTION
## Summary
- add Profile component with read-only user info
- register profile route
- open profile page when clicking nickname

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840653d88ac832997a7105c34470f87